### PR TITLE
Allow altternative way to provide type info to prevent F821 linting errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,4 @@ jobs:
         run: |
             python setup.py install
             rm -rf ./pyshader ./build ./egg-info
-            pytest --disable-warnings --junit-xml=results-packaged.xml -v --cov=pyshader || true
+            pytest -v --cov=pyshader

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ from pyshader import python2shader, vec3, vec4, mat4
 
 @python2shader
 def vertex_shader(
-    vertex_pos: ("input", 0, vec3),
-    transform: ("uniform", (0, 0), mat4),
-    out_pos: ("output", "Position", vec4),
+    vertex_pos=("input", 0, vec3),
+    transform=("uniform", (0, 0), mat4),
+    out_pos=("output", "Position", vec4),
 ):
     out_pos = transform * vec4(vertex_pos, 1.0)
 
 @python2shader
 def fragment_shader_flat(
-    color: ("uniform", (0, 1), vec3), out_color: ("output", 0, vec4),
+    color=("uniform", (0, 1), vec3), out_color=("output", 0, vec4),
 ):
     out_color = vec4(color, 1.0)  # noqa
 ```
@@ -167,7 +167,9 @@ or "fragment", to indicate the type of shader.
 
 #### Function arguments
 
-Each argument of your function must be annotated with a 3-element tuple:
+Each argument of your function must be annotated with a 3-element tuple.
+This may be done either using an annotation or a "default value". Both
+flavours are equally valid, but the latter may prevent linting issues.
 
 ```py
 @python2shader
@@ -175,6 +177,11 @@ def your_vertex_shader(
     argument_name: (resource_type, slot, type_info)
 ):
     ...
+# or
+@python2shader
+def your_vertex_shader(
+    argument_name=(resource_type, slot, type_info)
+):
 ```
 
 There are 6 possible resource types. These are specified as a string, but

--- a/examples_py/textures.py
+++ b/examples_py/textures.py
@@ -13,9 +13,9 @@ from pyshader import python2shader, ivec3, vec2, vec4
 # texture. Note that read() and write() always operate on either vec4 or ivec4.
 @python2shader
 def compute_shader_tex_add(
-    index: ("input", "GlobalInvocationId", ivec3),
-    tex1: ("texture", 0, "2d rg16i"),
-    tex2: ("texture", 1, "2d r32f"),
+    index=("input", "GlobalInvocationId", ivec3),
+    tex1=("texture", 0, "2d rg16i"),
+    tex2=("texture", 1, "2d r32f"),
 ):
     val = tex1.read(index.xy).xy  # ivec2
     val = vec2(val)  # cast to vec2
@@ -25,9 +25,9 @@ def compute_shader_tex_add(
 # A simple fragment shader that applies a texture to e.g. a mesh.
 @python2shader
 def fragment_shader_tex(
-    tex: ("texture", 0, "2d f32"),
-    sampler: ("sampler", 1, ""),
-    tcoord: ("input", 0, vec2),
-    out_color: ("output", 0, vec4),
+    tex=("texture", 0, "2d f32"),
+    sampler=("sampler", 1, ""),
+    tcoord=("input", 0, vec2),
+    out_color=("output", 0, vec4),
 ):
     out_color = tex.sample(sampler, tcoord)  # noqa

--- a/examples_py/triangle.py
+++ b/examples_py/triangle.py
@@ -7,9 +7,9 @@ from pyshader import python2shader, i32, vec2, vec3, vec4
 
 @python2shader
 def vertex_shader(
-    index: ("input", "VertexId", i32),
-    out_pos: ("output", "Position", vec4),
-    out_color: ("output", 0, vec3),
+    index=("input", "VertexId", i32),
+    out_pos=("output", "Position", vec4),
+    out_color=("output", 0, vec3),
 ):
     positions = [vec2(+0.0, -0.5), vec2(+0.5, +0.5), vec2(-0.5, +0.7)]
 
@@ -20,6 +20,6 @@ def vertex_shader(
 
 @python2shader
 def fragment_shader(
-    color: ("input", 0, vec3), out_color: ("output", 0, vec4),
+    color=("input", 0, vec3), out_color=("output", 0, vec4),
 ):
     out_color = vec4(color, 1.0)  # noqa


### PR DESCRIPTION
Closes #40

## The problem

We use annotations to specify shader type information using tuples, e.g.:
```py
@python2shader
def vertex_shader(
    index: ("input", "VertexId", i32),
    out_pos: ("output", "Position", vec4),
    out_color: ("output", 0, vec3),
):
    ...
```

Unfortunately, pyflakes (which we use via flake8), reports stuff like:
```
F821 undefined name 'VertexId'
F821 undefined name 'output'
...
```

### Solution in this PR

There may be (or come, e.g. PEP 593) ways to mark our type annotations to prevent pyflakes from seeing our strings as forward declarations, but these will likely make the spelling more complex.

A very simple solution (both in implementation and use) is to also allow default values to specify the shader type info. This information is as easy to obtain as the annotations. In usage, it is as simple as changing the above code to (replacing `: ` with `=`):
```py
@python2shader
def vertex_shader(
    index=("input", "VertexId", i32),
    out_pos=("output", "Position", vec4),
    out_color=("output", 0, vec3),
):
    ...
```