### PR TITLE
Several improvements, prevent stack corruption

### DIFF
--- a/pyshader/stdlib.py
+++ b/pyshader/stdlib.py
@@ -168,21 +168,24 @@ def tan(x):
 
 @extension(16, result_type="same")
 def asin(x):
-    """ Get asin(x)
+    """ Get the arc sine of x, an angle in radians.
+    The range of result values is [-π / 2, π / 2].
     """
     return math.asin(x)
 
 
 @extension(17, result_type="same")
 def acos(x):
-    """ Get acos(x)
+    """ Get the arc cosine of x, an angle in radians.
+    The range of result values is [0, π].
     """
     return math.acos(x)
 
 
 @extension(18, result_type="same")
 def atan(x):
-    """ Get atan(x)
+    """ Get the arc tangent of x, an angle in radians.
+    The range of result values is [-π / 2, π / 2].
     """
     return math.atan(x)
 
@@ -231,7 +234,9 @@ def atanh(x):
 
 @extension(25, result_type="same")
 def atan2(x, y):
-    """ Get atan2(x, y)
+    """ Get the arc tangent of x, an angle in radians.
+    The signs of x and y are used to determine what quadrant the angle is in.
+    The range of result values is [-π, π]
     """
     return math.atan2(x, y)
 
@@ -415,3 +420,8 @@ def nclamp(x, min_val, max_val):
     If x or y is NaN, the other is returned. If both are NaN, the result is NaN.
     """
     raise NotImplementedError()
+
+
+# %% all
+
+__all__ = list(tex_functions) + list(ext_functions)

--- a/tests/test_py.py
+++ b/tests/test_py.py
@@ -134,6 +134,51 @@ def test_texcomp_2d_rg32i():
         tex.write(index.xy, color)
 
 
+# %% test fails
+
+
+def test_fail_unvalid_names():
+    def compute_shader(index: ("input", "GlobalInvocationId", ivec3),):
+        color = foo  # noqa
+
+    with raises(pyshader.ShaderError):
+        pyshader.python2shader(compute_shader)
+
+
+def test_fail_unvalid_stlib_name():
+    def compute_shader(index: ("input", "GlobalInvocationId", ivec3),):
+        color = stdlib.foo  # noqa
+
+    with raises(pyshader.ShaderError):
+        pyshader.python2shader(compute_shader)
+
+
+def test_cannot_use_unresolved_globals():
+    def compute_shader(index: ("input", "GlobalInvocationId", ivec3),):
+        color = stdlib + 1.0  # noqa
+
+    with raises(pyshader.ShaderError):
+        pyshader.python2shader(compute_shader)
+
+
+def test_cannot_call_non_funcs():
+    def compute_shader1(
+        index: ("input", "GlobalInvocationId", ivec3), tex: ("texture", 0, "2d rg32i"),
+    ):
+        a = 1.0
+        a(1.0)
+
+    def compute_shader2(
+        index: ("input", "GlobalInvocationId", ivec3), tex: ("texture", 0, "2d rg32i"),
+    ):
+        a = 1.0()  # noqa
+
+    with raises(pyshader.ShaderError):
+        pyshader.python2shader(compute_shader1)
+    with raises(pyshader.ShaderError):
+        pyshader.python2shader(compute_shader2)
+
+
 # %% Utils for this module
 
 

--- a/tests/test_py_math.py
+++ b/tests/test_py_math.py
@@ -4,6 +4,7 @@ With this we can validate arithmetic, control flow etc.
 """
 
 import os
+import math
 import json
 import random
 import ctypes
@@ -116,6 +117,24 @@ def test_mul_div2():
     res = list(out[1])
     assert res[0::2] == [6 * i * 2 for i in values1]
     assert res[1::2] == [6 * i / 2 for i in values1]
+
+
+def test_math_constants():
+    @python2shader_and_validate
+    def compute_shader(
+        index: ("input", "GlobalInvocationId", i32), data2: ("buffer", 1, Array(f32)),
+    ):
+        if index % 2 == 0:
+            data2[index] = math.pi
+        else:
+            data2[index] = math.e
+
+    skip_if_no_wgpu()
+
+    out = compute_with_buffers({}, {1: ctypes.c_float * 10}, compute_shader, n=10)
+
+    res = list(out[1])
+    assert iters_close(res, [math.pi, math.e] * 5)
 
 
 # %% Extension functions
@@ -326,6 +345,7 @@ HASHES = {
     "test_add_sub2.compute_shader": ("eac80cea3cae0305", "785f2c0acdbe0cd3"),
     "test_mul_div1.compute_shader": ("889f742ee3d3a695", "3b804bb4b7b52de0"),
     "test_mul_div2.compute_shader": ("bb5f1d05c0b02dab", "7e9591cb2d93d067"),
+    "test_math_constants.compute_shader": ("425b33e1d60a6105", "ab0b82f58688bbc7"),
     "test_pow.compute_shader": ("c83ff35156e57f86", "4c41b41333f94ee9"),
     "test_sqrt.compute_shader": ("3fb9f30103054be5", "a18522c9c8bbf809"),
     "test_length.compute_shader": ("bcb9fb5793f33610", "2e0a4f0ac0f3468d"),


### PR DESCRIPTION
The compiler that translates Python bytecode to our IR handles globals, resolving them to the appropriate function calls eventually. To do this the globals are pushed on the parser-stack, but no code is emitted. This means that if we "leak" such a global, the stack of the IR is corrupt. This could happen when e.g. using a variable name that does not exist, resulting in really unfriendly error messages. This PR fixes that by tracking such globals much better.