### PR TITLE
A few fixes

### DIFF
--- a/pyshader/_generator_bc.py
+++ b/pyshader/_generator_bc.py
@@ -969,7 +969,14 @@ class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
         elif type1 is type2 and issubclass(type1, scalar_or_vector):
             # Types are equal and scalar or vector. Covers a lot of cases.
             result_id, type_id = self.obtain_value(type1)
-            if issubclass(reftype1, _types.Float):
+            if (
+                issubclass(type1, _types.Vector)
+                and issubclass(reftype1, _types.Float)
+                and op == "mmul"
+            ):
+                opcode = cc.OpDot  # special case
+                result_id, type_id = self.obtain_value(type1.subtype)
+            elif issubclass(reftype1, _types.Float):
                 opcode = FOPS[op]
             elif issubclass(reftype1, _types.Int):
                 opcode = IOPS[op]

--- a/pyshader/_generator_bc.py
+++ b/pyshader/_generator_bc.py
@@ -838,14 +838,15 @@ class Bytecode2SpirVGenerator(OpCodeDefinitions, BaseSpirVGenerator):
             self._stack.append(ac)
         elif issubclass(ob.type, _types.Vector):
             indices = []
+            # Wr support xyzw, rgba, stpq
             for c in name:
-                if c in "xr":
+                if c in "xrs":
                     indices.append(0)
-                elif c in "yg":
+                elif c in "ygt":
                     indices.append(1)
-                elif c in "zb":
+                elif c in "zbp":
                     indices.append(2)
-                elif c in "wa":
+                elif c in "waq":
                     indices.append(3)
                 else:
                     raise ShaderError(f"Invalid vector attribute {name}")

--- a/pyshader/py.py
+++ b/pyshader/py.py
@@ -914,6 +914,9 @@ class PyBytecode2Bytecode:
     def _op_binary_multiply(self, arg):
         self._binary_op("mul")
 
+    def _op_binary_matrix_multiply(self, arg):
+        self._binary_op("mmul")
+
     def _op_binary_true_divide(self, arg):
         # We use the fdiv opcode that only works for floats. Python
         # auto-converts ints to float when dividing. A shader does not.

--- a/pyshader/py.py
+++ b/pyshader/py.py
@@ -531,6 +531,11 @@ class PyBytecode2Bytecode:
     def _op_extended_arg(self, arg):
         pass
 
+    def _op_dup_top(self, arg):
+        ob = self._stack_pop()
+        self._stack.extend([ob, ob])
+        self.emit(op.co_dup_top)
+
     def _op_pop_top(self, arg):
         self._stack_pop()
         self.emit(op.co_pop_top)

--- a/tests/test_py_math.py
+++ b/tests/test_py_math.py
@@ -171,6 +171,28 @@ def test_mul_div3():
     assert res[1::2] == [-i * 2 for i in values1]
 
 
+def test_mul_dot():
+    @python2shader_and_validate
+    def compute_shader(
+        index: ("input", "GlobalInvocationId", i32),
+        data1: ("buffer", 0, Array(f32)),
+        data2: ("buffer", 1, Array(f32)),
+    ):
+        a = vec2(data1[index], data1[index])
+        data2[index] = a @ a
+
+    skip_if_no_wgpu()
+
+    values1 = [i - 5 for i in range(10)]
+
+    inp_arrays = {0: (ctypes.c_float * 10)(*values1)}
+    out_arrays = {1: ctypes.c_float * 10}
+    out = compute_with_buffers(inp_arrays, out_arrays, compute_shader)
+
+    res = list(out[1])
+    assert res == [i ** 2 * 2 for i in values1]
+
+
 def test_integer_div():
     @python2shader_and_validate
     def compute_shader(
@@ -505,6 +527,7 @@ HASHES = {
     "test_mul_div1.compute_shader": ("15609b10642943d4", "37608280de8c3af1"),
     "test_mul_div2.compute_shader": ("f4c102543e3f0339", "4655309b6e5008d6"),
     "test_mul_div3.compute_shader": ("3aec875ee04bc331", "4e66ca5ddfb1a95d"),
+    "test_mul_dot.compute_shader": ("980e7c16fe94780e", "d66618646e752d28"),
     "test_integer_div.compute_shader": ("3e957da5a67c96a8", "0250fbb9f4dcc27e"),
     "test_mul_modulo.compute_shader": ("28c42b8b719b94cf", "cd0f355d2f254e1d"),
     "test_math_constants.compute_shader": ("425b33e1d60a6105", "3b54fc67b1794011"),


### PR DESCRIPTION
* Implement dot product `v1 @ v2`.
* Implement swizzling with chars commonly used for texture coords.
* Add a Python bytecode that we did not support.